### PR TITLE
Updates per Moate (SOFTWARE-4751)

### DIFF
--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -135,13 +135,13 @@ def parse_options(args):
 	ops, args = getopt.getopt(args, 'u:d:')
     except getopt.GetoptError:
 	usage()
-    ops = dict(ops)
 
     passfd = None
 
-    if '-u' in ops: options.user     =     ops['-u']
-    if '-d' in ops: passfd           = int(ops['-d'])
-    if '-e' in ops: options.endpoint =     ops['-e']
+    for op, arg in ops:
+        if op == '-u': options.user     = arg
+        if op == '-d': passfd           = int(arg)
+        if op == '-e': options.endpoint = arg
 
     options.user, passwd = getpw(options.user, passfd)
     options.authstr = mkauthstr(options.user, passwd)

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -19,6 +19,7 @@ OPTIONS:
   -d passfd           specify open fd to read PASS
   -f passfile         specify path to file to open and read PASS
   -e ENDPOINT         specify REST endpoint
+  -o outfile          specify output file (default: write to stdout)
 
 PASS for USER is taken from the first of:
   1. -u USER:PASS
@@ -41,6 +42,7 @@ def usage(msg=None):
 class Options:
     endpoint = ENDPOINT
     user = "co_8.project_script"
+    outfile = None
     authstr = None
 
 
@@ -151,6 +153,7 @@ def parse_options(args):
         if op == '-d': passfd           = int(arg)
         if op == '-f': passfile         = arg
         if op == '-e': options.endpoint = arg
+        if op == '-o': options.outfile  = arg
 
     user, passwd = getpw(options.user, passfd, passfile)
     options.authstr = mkauthstr(user, passwd)
@@ -179,9 +182,17 @@ def get_osguser_groups():
              for pid, gids in pid_gids.items() }
 
 
-def print_usermap(osguser_groups):
+def print_usermap_to_file(osguser_groups, file):
     for osguser, groups in osguser_groups.items():
-        print("* {} {}".format(osguser, ",".join(groups)))
+        print("* {} {}".format(osguser, ",".join(groups)), file=file)
+
+
+def print_usermap(osguser_groups):
+    if options.outfile:
+        with open(options.outfile, "w") as w:
+            print_usermap_to_file(osguser_groups, w)
+    else:
+        print_usermap_to_file(osguser_groups, sys.stdout)
 
 
 def main(args):

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -136,6 +136,9 @@ def parse_options(args):
     except getopt.GetoptError:
 	usage()
 
+    if args:
+        usage("Extra arguments: %s" % repr(args))
+
     passfd = None
 
     for op, arg in ops:

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -139,9 +139,9 @@ def get_co_person_osguser(pid):
 
 def parse_options(args):
     try:
-	ops, args = getopt.getopt(args, 'u:d:f:e:o:h')
+        ops, args = getopt.getopt(args, 'u:d:f:e:o:h')
     except getopt.GetoptError:
-	usage()
+        usage()
 
     if args:
         usage("Extra arguments: %s" % repr(args))

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -139,7 +139,7 @@ def get_co_person_osguser(pid):
 
 def parse_options(args):
     try:
-	ops, args = getopt.getopt(args, 'u:d:')
+	ops, args = getopt.getopt(args, 'u:d:f:e:o:h')
     except getopt.GetoptError:
 	usage()
 

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -131,7 +131,10 @@ def get_co_person_osguser(pid):
 
 
 def parse_options(args):
-    ops, args = getopt.getopt(args, 'u:d:')
+    try:
+	ops, args = getopt.getopt(args, 'u:d:')
+    except getopt.GetoptError:
+	usage()
     ops = dict(ops)
 
     passfd = None

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -20,6 +20,7 @@ OPTIONS:
   -f passfile         specify path to file to open and read PASS
   -e ENDPOINT         specify REST endpoint
   -o outfile          specify output file (default: write to stdout)
+  -h                  display this help text
 
 PASS for USER is taken from the first of:
   1. -u USER:PASS
@@ -149,6 +150,7 @@ def parse_options(args):
     passfile = None
 
     for op, arg in ops:
+        if op == '-h': usage()
         if op == '-u': options.user     = arg
         if op == '-d': passfd           = int(arg)
         if op == '-f': passfile         = arg

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -71,7 +71,7 @@ def mkauthstr(user, passwd):
 
 
 def mkrequest(target, **kw):
-    url = options.endpoint + target
+    url = os.path.join(options.endpoint, target)
     if kw:
         url += "?" + "&".join( "{}={}".format(k,v) for k,v in kw.items() )
     req = urllib.request.Request(url)

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -152,8 +152,8 @@ def parse_options(args):
         if op == '-f': passfile         = arg
         if op == '-e': options.endpoint = arg
 
-    options.user, passwd = getpw(options.user, passfd, passfile)
-    options.authstr = mkauthstr(options.user, passwd)
+    user, passwd = getpw(options.user, passfd, passfile)
+    options.authstr = mkauthstr(user, passwd)
 
 
 def gid_pids_to_osguser_pid_gids(gid_pids, pid_osguser):


### PR DESCRIPTION
Add options per Moate's request:

```
   -f passfile         specify path to file to open and read PASS
   -o outfile          specify output file (default: write to stdout)
   -h                  usage output
```

As well as some small tweaks.