### PR TITLE
Add -c OSG_CO_ID option (SOFTWARE-4751)

### DIFF
--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -10,6 +10,7 @@ import urllib.request
 
 SCRIPT = os.path.basename(__file__)
 ENDPOINT = "https://registry-test.cilogon.org/registry/"
+OSG_CO_ID = 8
 
 
 _usage = f"""\
@@ -17,6 +18,7 @@ usage: [PASS=...] {SCRIPT} [OPTIONS]
 
 OPTIONS:
   -u USER[:PASS]      specify USER and optionally PASS on command line
+  -c OSG_CO_ID        specify OSG CO ID (default = {OSG_CO_ID})
   -d passfd           specify open fd to read PASS
   -f passfile         specify path to file to open and read PASS
   -e ENDPOINT         specify REST endpoint
@@ -42,6 +44,7 @@ def usage(msg=None):
 class Options:
     endpoint = ENDPOINT
     user = "co_8.project_script"
+    osg_co_id = OSG_CO_ID
     outfile = None
     authstr = None
 
@@ -87,8 +90,7 @@ def call_api(target, **kw):
 
 
 def get_osg_co_groups():
-    OSG_CO_ID = 8
-    return call_api("co_groups.json", coid=OSG_CO_ID)
+    return call_api("co_groups.json", coid=options.osg_co_id)
 
 
 # primary api calls
@@ -149,7 +151,7 @@ def get_co_person_osguser(pid):
 
 def parse_options(args):
     try:
-        ops, args = getopt.getopt(args, 'u:d:f:e:o:h')
+        ops, args = getopt.getopt(args, 'u:c:d:f:e:o:h')
     except getopt.GetoptError:
         usage()
 
@@ -162,6 +164,7 @@ def parse_options(args):
     for op, arg in ops:
         if op == '-h': usage()
         if op == '-u': options.user     = arg
+        if op == '-c': options.osg_co_id = int(arg)
         if op == '-d': passfd           = int(arg)
         if op == '-f': passfile         = arg
         if op == '-e': options.endpoint = arg

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -163,12 +163,12 @@ def parse_options(args):
 
     for op, arg in ops:
         if op == '-h': usage()
-        if op == '-u': options.user     = arg
+        if op == '-u': options.user      = arg
         if op == '-c': options.osg_co_id = int(arg)
-        if op == '-d': passfd           = int(arg)
-        if op == '-f': passfile         = arg
-        if op == '-e': options.endpoint = arg
-        if op == '-o': options.outfile  = arg
+        if op == '-d': passfd            = int(arg)
+        if op == '-f': passfile          = arg
+        if op == '-e': options.endpoint  = arg
+        if op == '-o': options.outfile   = arg
 
     user, passwd = getpw(options.user, passfd, passfile)
     options.authstr = mkauthstr(user, passwd)

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -5,6 +5,7 @@ import sys
 import json
 import getopt
 import collections
+import urllib.error
 import urllib.request
 
 
@@ -218,5 +219,9 @@ def main(args):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    try:
+        main(sys.argv[1:])
+    except urllib.error.HTTPError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
 

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -8,17 +8,19 @@ import collections
 import urllib.request
 
 
+SCRIPT = os.path.basename(__file__)
 ENDPOINT = "https://registry-test.cilogon.org/registry/"
 
 
-_usage = """\
-usage: [PASS=...] {script} [OPTIONS]
+_usage = f"""\
+usage: [PASS=...] {SCRIPT} [OPTIONS]
 
 OPTIONS:
   -u USER[:PASS]      specify USER and optionally PASS on command line
   -d passfd           specify open fd to read PASS
   -f passfile         specify path to file to open and read PASS
   -e ENDPOINT         specify REST endpoint
+                        (default = {ENDPOINT})
   -o outfile          specify output file (default: write to stdout)
   -h                  display this help text
 
@@ -27,16 +29,13 @@ PASS for USER is taken from the first of:
   2. -d passfd (read from fd)
   3. -f passfile (read from file)
   4. read from $PASS env var
-
-ENDPOINT defaults to {ENDPOINT}
 """
 
 def usage(msg=None):
     if msg:
         print(msg + "\n", file=sys.stderr)
 
-    script = os.path.basename(__file__)
-    print(_usage.format(script=script, ENDPOINT=ENDPOINT), file=sys.stderr)
+    print(_usage, file=sys.stderr)
     sys.exit()
 
 


### PR DESCRIPTION
Apparently co_8 is for the -test instance and co_7 is for prod.

I've also tidied up the usage output a bit and avoided dumping tracebacks for HTTP errors (unauthorized, in particular).