### PR TITLE
allow gids to be passed as strings (SOFTWARE-5057)

### DIFF
--- a/create_project.py
+++ b/create_project.py
@@ -137,7 +137,7 @@ def get_co_person_identifiers(pid):
 
 
 def get_co_group(gid):
-    grouplist = call_api("co_groups/%d.json" % gid) | get_datalist("CoGroups")
+    grouplist = call_api("co_groups/%s.json" % gid) | get_datalist("CoGroups")
     if not grouplist:
         raise RuntimeError("No such CO Group Id: %s" % gid)
     return grouplist[0]

--- a/group_fixup.py
+++ b/group_fixup.py
@@ -145,7 +145,7 @@ def get_co_person_identifiers(pid):
 
 
 def get_co_group(gid):
-    grouplist = call_api("co_groups/%d.json" % gid) | get_datalist("CoGroups")
+    grouplist = call_api("co_groups/%s.json" % gid) | get_datalist("CoGroups")
     if not grouplist:
         raise RuntimeError("No such CO Group Id: %s" % gid)
     return grouplist[0]
@@ -252,7 +252,7 @@ def show_group_identifiers(gid):
 
 
 def delete_identifier(id_):
-    return call_api2(DELETE, "identifiers/%d.json" % id_)
+    return call_api2(DELETE, "identifiers/%s.json" % id_)
 
 
 def rename_co_group(gid, group, newname):
@@ -268,7 +268,7 @@ def rename_co_group(gid, group, newname):
         "RequestType" : "CoGroups",
         "Version"     : "1.0"
     }
-    return call_api3(PUT, "co_groups/%d.json" % gid, data)
+    return call_api3(PUT, "co_groups/%s.json" % gid, data)
 
 
 def fixup_unixcluster_group(gid):


### PR DESCRIPTION
gids in retrieved data are strings; don't have a cow if we call one of our internal functions with a gid in string representation.

This was apparently causing problems for the fix-all pathway:

```
  File "/usr/local/bin/group_fixup.py", line 148, in get_co_group
    grouplist = call_api("co_groups/%d.json" % gid) | get_datalist("CoGroups")
TypeError: %d format: a number is required, not str
```