### PR TITLE
Provision group after other fixups (SOFTWARE-5187)

### DIFF
--- a/group_fixup.py
+++ b/group_fixup.py
@@ -14,6 +14,7 @@ SCRIPT = os.path.basename(__file__)
 ENDPOINT = "https://registry.cilogon.org/registry/"
 USER = "co_7.group_fixup"
 OSG_CO_ID = 7
+LDAP_PROV_ID = 6
 
 GET    = "GET"
 PUT    = "PUT"
@@ -31,6 +32,7 @@ OPTIONS:
   -f passfile         specify path to file to open and read PASS
   -e ENDPOINT         specify REST endpoint
                         (default = {ENDPOINT})
+  -p LDAP_PROV_ID     LDAP Provisioning Target ID (default = {LDAP_PROV_ID})
   -a                  show all UnixCluster autogroups, not just misnamed ones
   -i COGroupId        show fixup info for a specific CO Group
   -x COGroupId        run UnixCluster Group fixups for given CO Group Id
@@ -60,6 +62,7 @@ def usage(msg=None):
 class Options:
     endpoint  = ENDPOINT
     osg_co_id = OSG_CO_ID
+    prov_id   = LDAP_PROV_ID
     user      = USER
     authstr   = None
     fix_gid   = None
@@ -300,7 +303,7 @@ def fixup_all_unixcluster_groups():
 
 def parse_options(args):
     try:
-        ops, args = getopt.getopt(args, 'u:c:d:f:e:x:i:ah', ["fix-all"])
+        ops, args = getopt.getopt(args, 'u:c:d:f:e:x:i:p:ah', ["fix-all"])
     except getopt.GetoptError:
         usage()
 
@@ -319,6 +322,7 @@ def parse_options(args):
         if op == '-e': options.endpoint  = arg
         if op == '-x': options.fix_gid   = int(arg)
         if op == '-i': options.info_gid  = int(arg)
+        if op == '-p': options.prov_id   = int(arg)
         if op == '-a': options.showall   = True
 
         if op == '--fix-all': options.fix_all = True

--- a/group_fixup.py
+++ b/group_fixup.py
@@ -274,6 +274,17 @@ def rename_co_group(gid, group, newname):
     return call_api3(PUT, "co_groups/%s.json" % gid, data)
 
 
+def provision_group(gid):
+    prov_id = options.prov_id
+    path = f"co_provisioning_targets/provision/{prov_id}/cogroupid:{gid}.json"
+    data = {
+        "RequestType" : "CoGroupProvisioning",
+        "Version"     : "1.0",
+        "Synchronous" : True
+    }
+    return call_api3(POST, path, data)
+
+
 def fixup_unixcluster_group(gid):
     group = get_co_group(gid)
     oldname = group["Name"]
@@ -286,6 +297,8 @@ def fixup_unixcluster_group(gid):
         rename_co_group(gid, group, newname)
     for id_ in ids_to_delete:
         delete_identifier(id_)
+
+    provision_group(gid)
 
     # http errors raise exceptions, so at this point we apparently succeeded
     print(":thumbsup:")


### PR DESCRIPTION
Turns out there is no way to get this provisioning target id (for a given group) from the rest api, nor to list the available provisioning targets.  as far as i can tell, these can only be found on the cilogon web interface.  Well, at least there is only a single provisioning target ("Primary LDAP") for the entire CO.

I've tested this against my own group (`carl.edquist`, gid `6`), and I confirm that the provisioned timestamp on [the cilogon page](https://registry.cilogon.org/registry/co_groups/provision/671) gets updated accordingly to reflect the success.  So, seems to work!