### PR TITLE
Update project_usermap creation script (INF-1060)

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -36,6 +36,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip --cache-dir ~/pip-cache install pylint
+        pip --cache-dir ~/pip-cache install ldap3
     - name: Run Pylint
       env:
         PYTHON_FILES: ${{ needs.python-files.outputs.filelist }}

--- a/comanage_scripts_utils.py
+++ b/comanage_scripts_utils.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+import json
+import urllib.error
+import urllib.request
+from ldap3 import Server, Connection, ALL, ALL_ATTRIBUTES, SAFE_SYNC
+
+MIN_TIMEOUT = 5
+MAX_TIMEOUT = 625
+TIMEOUTMULTIPLE = 5
+
+GET    = "GET"
+PUT    = "PUT"
+POST   = "POST"
+DELETE = "DELETE"
+
+
+def getpw(user, passfd, passfile):
+    if ":" in user:
+        user, pw = user.split(":", 1)
+    elif passfd is not None:
+        pw = os.fdopen(passfd).readline().rstrip("\n")
+    elif passfile is not None:
+        pw = open(passfile).readline().rstrip("\n")
+    elif "PASS" in os.environ:
+        pw = os.environ["PASS"]
+    else:
+        raise PermissionError
+        #when script needs to say PASS required, raise a permission error
+        #usage("PASS required")
+    return user, pw
+
+
+def mkauthstr(user, passwd):
+    from base64 import encodebytes
+    raw_authstr = "%s:%s" % (user, passwd)
+    return encodebytes(raw_authstr.encode()).decode().replace("\n", "")
+
+
+def mkrequest(method, target, data, endpoint, authstr, **kw):
+    url = os.path.join(endpoint, target)
+    if kw:
+        url += "?" + "&".join("{}={}".format(k,v) for k,v in kw.items())
+    req = urllib.request.Request(url, json.dumps(data).encode("utf-8"))
+    req.add_header("Authorization", "Basic %s" % authstr)
+    req.add_header("Content-Type", "application/json")
+    req.get_method = lambda: method
+    return req
+
+
+def call_api(target, endpoint, authstr, **kw):
+    return call_api2(GET, target, endpoint, authstr, **kw)
+
+
+def call_api2(method, target, endpoint, authstr, **kw):
+    return call_api3(method, target, data=None, endpoint=endpoint, authstr=authstr, **kw)
+
+
+def call_api3(method, target, data, endpoint, authstr, **kw):
+    req = mkrequest(method, target, data, endpoint, authstr, **kw)
+    trying = True
+    currentTimeout = MIN_TIMEOUT
+    while trying:
+        try:
+            resp = urllib.request.urlopen(req, timeout=currentTimeout)
+            payload = resp.read()
+            trying = False
+        except urllib.error.URLError as exception:
+            if currentTimeout < MAX_TIMEOUT:
+                currentTimeout *= TIMEOUTMULTIPLE
+            else:
+                sys.exit(
+                    f"Exception raised after maximum retrys and/or timeout {MAX_TIMEOUT} seconds reached. "
+                    + f"Exception reason: {exception.reason}.\n Request: {req.full_url}"
+                )
+
+    return json.loads(payload) if payload else None
+
+
+def get_osg_co_groups(osg_co_id, endpoint, authstr):
+    return call_api("co_groups.json", endpoint, authstr, coid=osg_co_id)
+
+
+def get_co_group_identifiers(gid, endpoint, authstr):
+    return call_api("identifiers.json", endpoint, authstr, cogroupid=gid)
+
+
+def get_co_group_members(gid, endpoint, authstr):
+    return call_api("co_group_members.json", endpoint, authstr, cogroupid=gid)
+
+
+def get_co_person_identifiers(pid, endpoint, authstr):
+    return call_api("identifiers.json", endpoint, authstr, copersonid=pid)
+
+
+def get_co_group(gid, endpoint, authstr):
+    resp_data = call_api("co_groups/%s.json" % gid, endpoint, authstr)
+    grouplist = get_datalist(resp_data, "CoGroups")
+    if not grouplist:
+        raise RuntimeError("No such CO Group Id: %s" % gid)
+    return grouplist[0]
+
+
+def get_identifier(id_, endpoint, authstr):
+    resp_data = call_api("identifiers/%s.json" % id_, endpoint, authstr)
+    idfs = get_datalist(resp_data, "Identifiers")
+    if not idfs:
+        raise RuntimeError("No such Identifier Id: %s" % id_)
+    return idfs[0]
+
+
+def get_unix_cluster_groups(ucid, endpoint, authstr):
+    return call_api("unix_cluster/unix_cluster_groups.json", endpoint, authstr, unix_cluster_id=ucid)
+
+
+def get_unix_cluster_groups_ids(ucid, endpoint, authstr):
+    unix_cluster_groups = get_unix_cluster_groups(ucid, endpoint, authstr)
+    return set(group["CoGroupId"] for group in unix_cluster_groups["UnixClusterGroups"])
+
+
+def delete_identifier(id_, endpoint, authstr):
+    return call_api2(DELETE, "identifiers/%s.json" % id_, endpoint, authstr)
+
+
+def get_datalist(data, listname):
+    return data[listname] if data else []
+
+
+def get_ldap_groups(ldap_server, ldap_user, ldap_authtok):
+    ldap_group_osggids = set()
+    server = Server(ldap_server, get_info=ALL)
+    connection = Connection(server, ldap_user, ldap_authtok, client_strategy=SAFE_SYNC, auto_bind=True)
+    _, _, response, _ = connection.search("ou=groups,o=OSG,o=CO,dc=cilogon,dc=org", "(cn=*)", attributes=ALL_ATTRIBUTES)
+    for group in response:
+        ldap_group_osggids.add(group["attributes"]["gidNumber"])
+    return ldap_group_osggids
+
+
+def identifier_from_list(id_list, id_type):
+    id_type_list = [id["Type"] for id in id_list]
+    try:
+        id_index = id_type_list.index(id_type)
+        return id_list[id_index]["Identifier"]
+    except ValueError:
+        return None
+
+
+def identifier_matches(id_list, id_type, regex_string):
+    pattern = re.compile(regex_string)
+    value = identifier_from_list(id_list, id_type)
+    return (value is not None) & (pattern.match(value) is not None)
+
+
+def rename_co_group(gid, group, newname, endpoint, authstr):
+    # minimal edit CoGroup Request includes Name+CoId+Status+Version
+    new_group_info = {
+        "Name"    : newname,
+        "CoId"    : group["CoId"],
+        "Status"  : group["Status"],
+        "Version" : group["Version"]
+    }
+    data = {
+        "CoGroups"    : [new_group_info],
+        "RequestType" : "CoGroups",
+        "Version"     : "1.0"
+    }
+    return call_api3(PUT, "co_groups/%s.json" % gid, data, endpoint, authstr)
+
+
+def add_identifier_to_group(gid, type, identifier_value, endpoint, authstr):
+    new_identifier_info = {
+        "Version": "1.0",
+        "Type": type,
+        "Identifier": identifier_value,
+        "Login": False,
+        "Person": {"Type": "Group", "Id": str(gid)},
+        "Status": "Active",
+    }
+    data = {
+        "RequestType": "Identifiers",
+        "Version": "1.0",
+        "Identifiers": [new_identifier_info],
+    }
+    return call_api3(POST, "identifiers.json", data, endpoint, authstr)
+
+
+def add_unix_cluster_group(gid, ucid, endpoint, authstr):
+    data = {
+        "RequestType": "UnixClusterGroups",
+        "Version": "1.0",
+        "UnixClusterGroups": [{"Version": "1.0", "UnixClusterId": ucid, "CoGroupId": gid}],
+    }
+    return call_api3(POST, "unix_cluster/unix_cluster_groups.json", data, endpoint, authstr)
+
+
+def provision_group(gid, provision_target, endpoint, authstr):
+    path = f"co_provisioning_targets/provision/{provision_target}/cogroupid:{gid}.json"
+    data = {
+        "RequestType" : "CoGroupProvisioning",
+        "Version"     : "1.0",
+        "Synchronous" : True
+    }
+    return call_api3(POST, path, data, endpoint, authstr)
+
+def provision_group_members(gid, prov_id, endpoint, authstr):
+    data = {
+        "RequestType" : "CoPersonProvisioning",
+        "Version"     : "1.0",
+        "Synchronous" : True
+    }
+    responses = {}
+    for member in get_co_group_members(gid, endpoint, authstr)["CoGroupMembers"]:
+        if member["Person"]["Type"] == "CO":
+            pid = member["Person"]["Id"]
+            path = f"co_provisioning_targets/provision/{prov_id}/copersonid:{pid}.json"
+            responses[pid] = call_api3(POST, path, data, endpoint, authstr)
+    return responses

--- a/comanage_scripts_utils.py
+++ b/comanage_scripts_utils.py
@@ -8,9 +8,11 @@ import urllib.error
 import urllib.request
 from ldap3 import Server, Connection, ALL, ALL_ATTRIBUTES, SAFE_SYNC
 
+
 MIN_TIMEOUT = 5
 MAX_TIMEOUT = 625
 TIMEOUTMULTIPLE = 5
+
 
 GET    = "GET"
 PUT    = "PUT"
@@ -73,7 +75,7 @@ def call_api3(method, target, data, endpoint, authstr, **kw):
                 currentTimeout *= TIMEOUTMULTIPLE
             else:
                 sys.exit(
-                    f"Exception raised after maximum retrys and/or timeout {MAX_TIMEOUT} seconds reached. "
+                    f"Exception raised after maximum number of retries and/or timeout {MAX_TIMEOUT} seconds reached. "
                     + f"Exception reason: {exception.reason}.\n Request: {req.full_url}"
                 )
 

--- a/group_fixup.py
+++ b/group_fixup.py
@@ -151,7 +151,6 @@ def show_group_identifiers(gid):
         print('  ** Identifier Ids to delete: %s' % ', '.join(ids_to_delete))
 
 
-
 # fixup functions
 
 
@@ -242,4 +241,3 @@ if __name__ == "__main__":
     except (RuntimeError, urllib.error.HTTPError) as e:
         print(e, file=sys.stderr)
         sys.exit(1)
-

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
+import re
 import os
 import sys
 import getopt
+import subprocess
 import collections
 import urllib.error
 import urllib.request
@@ -13,6 +15,36 @@ SCRIPT = os.path.basename(__file__)
 ENDPOINT = "https://registry-test.cilogon.org/registry/"
 OSG_CO_ID = 8
 
+LDAP_AUTH_COMMAND = [
+    "awk", "/ldap_default_authtok/ {print $3}", "/etc/sssd/conf.d/0060_domain_CILOGON.ORG.conf",
+]
+
+LDAP_GROUP_MEMBERS_COMMAND = [
+    "ldapsearch",
+    "-H",
+    "ldaps://ldap.cilogon.org",
+    "-D",
+    "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org",
+    "-w", "{}",
+    "-b",
+    "ou=groups,o=OSG,o=CO,dc=cilogon,dc=org",
+    "-s",
+    "one",
+    "(cn=*)",
+]
+
+LDAP_ACTIVE_USERS_COMMAND = [
+    "ldapsearch",
+    "-LLL",
+    "-H", "ldaps://ldap.cilogon.org",
+    "-D", "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org",
+    "-x",
+    "-w",  "{}",
+    "-b", "ou=people,o=OSG,o=CO,dc=cilogon,dc=org",
+    "(isMemberOf=CO:members:active)", "voPersonApplicationUID",
+    "|", "grep", "voPersonApplicationUID",
+    "|", "sort",
+]
 
 _usage = f"""\
 usage: [PASS=...] {SCRIPT} [OPTIONS]
@@ -64,11 +96,17 @@ def get_osg_co_groups__map():
     return { g["Id"]: g["Name"] for g in data }
 
 
-def co_group_is_ospool(gid):
+def co_group_is_project(gid):
     #print(f"co_group_is_ospool({gid})")
     resp_data = utils.get_co_group_identifiers(gid, options.endpoint, options.authstr)
     data = utils.get_datalist(resp_data, "Identifiers")
     return any( i["Type"] == "ospoolproject" for i in data )
+
+
+def get_co_group_osggid(gid):
+    resp_data = get_co_group_identifiers(gid)
+    data = get_datalist(resp_data, "Identifiers")
+    return list(filter(lambda x : x["Type"] == "osggid", data))[0]["Identifier"]
 
 
 def get_co_group_members__pids(gid):
@@ -115,6 +153,84 @@ def parse_options(args):
         usage("PASS required")
 
 
+def get_ldap_group_members_data():
+    gidNumber_str = "gidNumber: "
+    gidNumber_regex = re.compile(gidNumber_str)
+    member_str = f"hasMember: "
+    member_regex = re.compile(member_str)
+
+    auth_str = subprocess.run(
+            LDAP_AUTH_COMMAND,
+            stdout=subprocess.PIPE
+            ).stdout.decode('utf-8').strip()
+    
+    ldap_group_members_command = LDAP_GROUP_MEMBERS_COMMAND
+    ldap_group_members_command[LDAP_GROUP_MEMBERS_COMMAND.index("{}")] = auth_str
+
+    data_file = subprocess.run(
+        ldap_group_members_command, stdout=subprocess.PIPE).stdout.decode('utf-8').split('\n')
+
+    search_results = list(filter( 
+        lambda x: not re.compile("#|dn|cn|objectClass").match(x),
+        (line for line in data_file)))
+        
+    search_results.reverse()
+
+    group_data_dict = dict()
+    index = 0
+    while index < len(search_results) - 1:
+        while not gidNumber_regex.match(search_results[index]):
+            index += 1
+        gid = search_results[index].replace(gidNumber_str, "")
+        members_list = []
+        while search_results[index] != "":
+            if member_regex.match(search_results[index]):
+                members_list.append(search_results[index].replace(member_str, ""))
+            index += 1
+        group_data_dict[gid] = members_list
+        index += 1
+
+    return group_data_dict
+
+
+def get_ldap_active_users():
+    auth_str = subprocess.run(
+            LDAP_AUTH_COMMAND,
+            stdout=subprocess.PIPE
+            ).stdout.decode('utf-8').strip()
+    
+    ldap_active_users_command = LDAP_ACTIVE_USERS_COMMAND
+    ldap_active_users_command[LDAP_ACTIVE_USERS_COMMAND.index("{}")] = auth_str
+
+    active_users = subprocess.run(ldap_active_users_command, stdout=subprocess.PIPE).stdout.decode('utf-8').split('\n')
+    users = set(line.replace("voPersonApplicationUID: ", "") if re.compile("dn: voPerson*") else "" for line in active_users)
+    return users
+
+
+def create_user_to_projects_map(project_to_user_map, active_users, osggids_to_names):
+    users_to_projects_map = dict()
+    for osggid in project_to_user_map:
+        for user in project_to_user_map[osggid]:
+            if user in active_users:
+                if user not in users_to_projects_map:
+                    users_to_projects_map[user] = [osggids_to_names[osggid]]
+                else:
+                    users_to_projects_map[user].append(osggids_to_names[osggid])
+
+    return users_to_projects_map
+
+
+def get_co_api_data():
+    #TODO add cacheing for COManage API data
+
+    groups = get_osg_co_groups__map()
+    project_osggids_to_name = dict()
+    for id,name in groups.items():
+        if co_group_is_project(id):
+            project_osggids_to_name[get_co_group_osggid(id)] = name
+    return project_osggids_to_name
+
+
 def gid_pids_to_osguser_pid_gids(gid_pids, pid_osguser):
     pid_gids = collections.defaultdict(set)
 
@@ -134,17 +250,29 @@ def filter_by_group(pid_gids, groups, filter_group_name):
 
 
 def get_osguser_groups(filter_group_name=None):
-    groups = get_osg_co_groups__map()
-    ospool_gids = filter(co_group_is_ospool, groups)
-    gid_pids = { gid: get_co_group_members__pids(gid) for gid in ospool_gids }
-    all_pids = set( pid for gid in gid_pids for pid in gid_pids[gid] )
-    pid_osguser = { pid: get_co_person_osguser(pid) for pid in all_pids }
-    pid_gids = gid_pids_to_osguser_pid_gids(gid_pids, pid_osguser)
-    if filter_group_name is not None:
-        pid_gids = filter_by_group(pid_gids, groups, filter_group_name)
+    project_osggids_to_name = get_co_api_data()
+    ldap_groups_members = get_ldap_group_members_data()
+    ldap_users = get_ldap_active_users()
 
-    return { pid_osguser[pid]: sorted(map(groups.get, gids))
-             for pid, gids in pid_gids.items() }
+    active_project_osggids = set(ldap_groups_members.keys()).intersection(set(project_osggids_to_name.keys()))
+    project_to_user_map = {
+        osggid : ldap_groups_members[osggid]
+        for osggid in active_project_osggids
+        }
+    all_project_users = set(
+        username for osggid in project_to_user_map for username in project_to_user_map[osggid]
+        )
+    all_active_project_users = all_project_users.intersection(ldap_users)
+    usernames_to_project_map = create_user_to_projects_map(
+                                project_to_user_map,  
+                                all_active_project_users,
+                                project_osggids_to_name,
+                                )
+    
+    #if filter_group_name is not None:
+        #pid_gids = filter_by_group(pid_gids, groups, filter_group_name)
+
+    return usernames_to_project_map
 
 
 def print_usermap_to_file(osguser_groups, file):

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -2,19 +2,16 @@
 
 import os
 import sys
-import json
 import getopt
 import collections
 import urllib.error
 import urllib.request
+import comanage_scripts_utils as utils
 
 
 SCRIPT = os.path.basename(__file__)
 ENDPOINT = "https://registry-test.cilogon.org/registry/"
 OSG_CO_ID = 8
-MINTIMEOUT = 5
-MAXTIMEOUT = 625
-TIMEOUTMULTIPLE = 5
 
 
 _usage = f"""\
@@ -29,8 +26,6 @@ OPTIONS:
                         (default = {ENDPOINT})
   -o outfile          specify output file (default: write to stdout)
   -g filter_group     filter users by group name (eg, 'ap1-login')
-  -t minTimeout       set minimum timeout, in seconds, for API call (default to {MINTIMEOUT})
-  -T maxTimeout       set maximum timeout, in seconds, for API call (default to {MAXTIMEOUT})
   -h                  display this help text
 
 PASS for USER is taken from the first of:
@@ -55,118 +50,45 @@ class Options:
     outfile = None
     authstr = None
     filtergrp = None
-    min_timeout = MINTIMEOUT
-    max_timeout = MAXTIMEOUT
 
 
 options = Options()
-
-
-def getpw(user, passfd, passfile):
-    if ':' in user:
-        user, pw = user.split(':', 1)
-    elif passfd is not None:
-        pw = os.fdopen(passfd).readline().rstrip('\n')
-    elif passfile is not None:
-        pw = open(passfile).readline().rstrip('\n')
-    elif 'PASS' in os.environ:
-        pw = os.environ['PASS']
-    else:
-        usage("PASS required")
-    return user, pw
-
-
-def mkauthstr(user, passwd):
-    from base64 import encodebytes
-    raw_authstr = '%s:%s' % (user, passwd)
-    return encodebytes(raw_authstr.encode()).decode().replace('\n', '')
-
-
-def mkrequest(target, **kw):
-    url = os.path.join(options.endpoint, target)
-    if kw:
-        url += "?" + "&".join( "{}={}".format(k,v) for k,v in kw.items() )
-    req = urllib.request.Request(url)
-    req.add_header("Authorization", "Basic %s" % options.authstr)
-    req.get_method = lambda: 'GET'
-    return req
-
-
-def call_api(target, **kw):
-    req = mkrequest(target, **kw)
-    trying = True
-    currentTimeout = options.min_timeout
-    while trying:
-        try:
-            resp = urllib.request.urlopen(req, timeout=currentTimeout)
-            payload = resp.read()
-            trying = False
-        except urllib.error.URLError as exception:
-            if (currentTimeout < options.max_timeout):
-                currentTimeout *= TIMEOUTMULTIPLE
-            else:
-                sys.exit(f"Exception raised after maximum timeout {options.max_timeout} seconds reached. "
-                         + f"Exception reason: {exception.reason}.\n Request: {req.full_url}")
-    
-    return json.loads(payload) if payload else None
-
-
-def get_osg_co_groups():
-    return call_api("co_groups.json", coid=options.osg_co_id)
-
-
-# primary api calls
-
-def get_co_group_identifiers(gid):
-    return call_api("identifiers.json", cogroupid=gid)
-
-
-def get_co_group_members(gid):
-    return call_api("co_group_members.json", cogroupid=gid)
-
-
-def get_co_person_identifiers(pid):
-    return call_api("identifiers.json", copersonid=pid)
-
-
-def get_datalist(data, listname):
-    return data[listname] if data else []
 
 
 # api call results massagers
 
 def get_osg_co_groups__map():
     #print("get_osg_co_groups__map()")
-    resp_data = get_osg_co_groups()
-    data = get_datalist(resp_data, "CoGroups")
+    resp_data = utils.get_osg_co_groups(options.osg_co_id, options.endpoint, options.authstr)
+    data = utils.get_datalist(resp_data, "CoGroups")
     return { g["Id"]: g["Name"] for g in data }
 
 
 def co_group_is_ospool(gid):
     #print(f"co_group_is_ospool({gid})")
-    resp_data = get_co_group_identifiers(gid)
-    data = get_datalist(resp_data, "Identifiers")
+    resp_data = utils.get_co_group_identifiers(gid, options.endpoint, options.authstr)
+    data = utils.get_datalist(resp_data, "Identifiers")
     return any( i["Type"] == "ospoolproject" for i in data )
 
 
 def get_co_group_members__pids(gid):
     #print(f"get_co_group_members__pids({gid})")
-    resp_data = get_co_group_members(gid)
-    data = get_datalist(resp_data, "CoGroupMembers")
+    resp_data = utils.get_co_group_members(gid,  options.endpoint, options.authstr)
+    data = utils.get_datalist(resp_data, "CoGroupMembers")
     return [ m["Person"]["Id"] for m in data ]
 
 
 def get_co_person_osguser(pid):
     #print(f"get_co_person_osguser({pid})")
-    resp_data = get_co_person_identifiers(pid)
-    data = get_datalist(resp_data, "Identifiers")
+    resp_data = utils.get_co_person_identifiers(pid, options.endpoint, options.authstr)
+    data = utils.get_datalist(resp_data, "Identifiers")
     typemap = { i["Type"]: i["Identifier"] for i in data }
     return typemap.get("osguser")
 
 
 def parse_options(args):
     try:
-        ops, args = getopt.getopt(args, 'u:c:d:f:g:e:o:t:T:h')
+        ops, args = getopt.getopt(args, 'u:c:d:f:g:e:o:h')
     except getopt.GetoptError:
         usage()
 
@@ -185,11 +107,12 @@ def parse_options(args):
         if op == '-e': options.endpoint   = arg
         if op == '-o': options.outfile    = arg
         if op == '-g': options.filtergrp  = arg
-        if op == '-t': options.min_timeout = float(arg)
-        if op == '-T': options.max_timeout = float(arg)
 
-    user, passwd = getpw(options.user, passfd, passfile)
-    options.authstr = mkauthstr(user, passwd)
+    try:
+        user, passwd = utils.getpw(options.user, passfd, passfile)
+        options.authstr = utils.mkauthstr(user, passwd)
+    except PermissionError:
+        usage("PASS required")
 
 
 def gid_pids_to_osguser_pid_gids(gid_pids, pid_osguser):

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -233,7 +233,7 @@ def parse_options(args):
 def get_ldap_group_members_data():
     gidNumber_str = "gidNumber: "
     gidNumber_regex = re.compile(gidNumber_str)
-    member_str = f"hasMember: "
+    member_str = "hasMember: "
     member_regex = re.compile(member_str)
 
     auth_str = subprocess.run(

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -156,7 +156,7 @@ def parse_options(args):
 def get_ldap_group_members_data():
     gidNumber_str = "gidNumber: "
     gidNumber_regex = re.compile(gidNumber_str)
-    member_str = f"hasMember: "
+    member_str = "hasMember: "
     member_regex = re.compile(member_str)
 
     auth_str = subprocess.run(

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
+import re
 import os
 import sys
 import json
 import getopt
+import subprocess
 import collections
 import urllib.error
 import urllib.request
@@ -16,6 +18,36 @@ MINTIMEOUT = 5
 MAXTIMEOUT = 625
 TIMEOUTMULTIPLE = 5
 
+LDAP_AUTH_COMMAND = [
+    "awk", "/ldap_default_authtok/ {print $3}", "/etc/sssd/conf.d/0060_domain_CILOGON.ORG.conf",
+]
+
+LDAP_GROUP_MEMBERS_COMMAND = [
+    "ldapsearch",
+    "-H",
+    "ldaps://ldap.cilogon.org",
+    "-D",
+    "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org",
+    "-w", "{}",
+    "-b",
+    "ou=groups,o=OSG,o=CO,dc=cilogon,dc=org",
+    "-s",
+    "one",
+    "(cn=*)",
+]
+
+LDAP_ACTIVE_USERS_COMMAND = [
+    "ldapsearch",
+    "-LLL",
+    "-H", "ldaps://ldap.cilogon.org",
+    "-D", "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org",
+    "-x",
+    "-w",  "{}",
+    "-b", "ou=people,o=OSG,o=CO,dc=cilogon,dc=org",
+    "(isMemberOf=CO:members:active)", "voPersonApplicationUID",
+    "|", "grep", "voPersonApplicationUID",
+    "|", "sort",
+]
 
 _usage = f"""\
 usage: [PASS=...] {SCRIPT} [OPTIONS]
@@ -142,11 +174,17 @@ def get_osg_co_groups__map():
     return { g["Id"]: g["Name"] for g in data }
 
 
-def co_group_is_ospool(gid):
+def co_group_is_project(gid):
     #print(f"co_group_is_ospool({gid})")
     resp_data = get_co_group_identifiers(gid)
     data = get_datalist(resp_data, "Identifiers")
     return any( i["Type"] == "ospoolproject" for i in data )
+
+
+def get_co_group_osggid(gid):
+    resp_data = get_co_group_identifiers(gid)
+    data = get_datalist(resp_data, "Identifiers")
+    return list(filter(lambda x : x["Type"] == "osggid", data))[0]["Identifier"]
 
 
 def get_co_group_members__pids(gid):
@@ -192,6 +230,84 @@ def parse_options(args):
     options.authstr = mkauthstr(user, passwd)
 
 
+def get_ldap_group_members_data():
+    gidNumber_str = "gidNumber: "
+    gidNumber_regex = re.compile(gidNumber_str)
+    member_str = f"hasMember: "
+    member_regex = re.compile(member_str)
+
+    auth_str = subprocess.run(
+            LDAP_AUTH_COMMAND,
+            stdout=subprocess.PIPE
+            ).stdout.decode('utf-8').strip()
+    
+    ldap_group_members_command = LDAP_GROUP_MEMBERS_COMMAND
+    ldap_group_members_command[LDAP_GROUP_MEMBERS_COMMAND.index("{}")] = auth_str
+
+    data_file = subprocess.run(
+        ldap_group_members_command, stdout=subprocess.PIPE).stdout.decode('utf-8').split('\n')
+
+    search_results = list(filter( 
+        lambda x: not re.compile("#|dn|cn|objectClass").match(x),
+        (line for line in data_file)))
+        
+    search_results.reverse()
+
+    group_data_dict = dict()
+    index = 0
+    while index < len(search_results) - 1:
+        while not gidNumber_regex.match(search_results[index]):
+            index += 1
+        gid = search_results[index].replace(gidNumber_str, "")
+        members_list = []
+        while search_results[index] != "":
+            if member_regex.match(search_results[index]):
+                members_list.append(search_results[index].replace(member_str, ""))
+            index += 1
+        group_data_dict[gid] = members_list
+        index += 1
+
+    return group_data_dict
+
+
+def get_ldap_active_users():
+    auth_str = subprocess.run(
+            LDAP_AUTH_COMMAND,
+            stdout=subprocess.PIPE
+            ).stdout.decode('utf-8').strip()
+    
+    ldap_active_users_command = LDAP_ACTIVE_USERS_COMMAND
+    ldap_active_users_command[LDAP_ACTIVE_USERS_COMMAND.index("{}")] = auth_str
+
+    active_users = subprocess.run(ldap_active_users_command, stdout=subprocess.PIPE).stdout.decode('utf-8').split('\n')
+    users = set(line.replace("voPersonApplicationUID: ", "") if re.compile("dn: voPerson*") else "" for line in active_users)
+    return users
+
+
+def create_user_to_projects_map(project_to_user_map, active_users, osggids_to_names):
+    users_to_projects_map = dict()
+    for osggid in project_to_user_map:
+        for user in project_to_user_map[osggid]:
+            if user in active_users:
+                if user not in users_to_projects_map:
+                    users_to_projects_map[user] = [osggids_to_names[osggid]]
+                else:
+                    users_to_projects_map[user].append(osggids_to_names[osggid])
+
+    return users_to_projects_map
+
+
+def get_co_api_data():
+    #TODO add cacheing for COManage API data
+
+    groups = get_osg_co_groups__map()
+    project_osggids_to_name = dict()
+    for id,name in groups.items():
+        if co_group_is_project(id):
+            project_osggids_to_name[get_co_group_osggid(id)] = name
+    return project_osggids_to_name
+
+
 def gid_pids_to_osguser_pid_gids(gid_pids, pid_osguser):
     pid_gids = collections.defaultdict(set)
 
@@ -211,17 +327,29 @@ def filter_by_group(pid_gids, groups, filter_group_name):
 
 
 def get_osguser_groups(filter_group_name=None):
-    groups = get_osg_co_groups__map()
-    ospool_gids = filter(co_group_is_ospool, groups)
-    gid_pids = { gid: get_co_group_members__pids(gid) for gid in ospool_gids }
-    all_pids = set( pid for gid in gid_pids for pid in gid_pids[gid] )
-    pid_osguser = { pid: get_co_person_osguser(pid) for pid in all_pids }
-    pid_gids = gid_pids_to_osguser_pid_gids(gid_pids, pid_osguser)
-    if filter_group_name is not None:
-        pid_gids = filter_by_group(pid_gids, groups, filter_group_name)
+    project_osggids_to_name = get_co_api_data()
+    ldap_groups_members = get_ldap_group_members_data()
+    ldap_users = get_ldap_active_users()
 
-    return { pid_osguser[pid]: sorted(map(groups.get, gids))
-             for pid, gids in pid_gids.items() }
+    active_project_osggids = set(ldap_groups_members.keys()).intersection(set(project_osggids_to_name.keys()))
+    project_to_user_map = {
+        osggid : ldap_groups_members[osggid]
+        for osggid in active_project_osggids
+        }
+    all_project_users = set(
+        username for osggid in project_to_user_map for username in project_to_user_map[osggid]
+        )
+    all_active_project_users = all_project_users.intersection(ldap_users)
+    usernames_to_project_map = create_user_to_projects_map(
+                                project_to_user_map,  
+                                all_active_project_users,
+                                project_osggids_to_name,
+                                )
+    
+    #if filter_group_name is not None:
+        #pid_gids = filter_by_group(pid_gids, groups, filter_group_name)
+
+    return usernames_to_project_map
 
 
 def print_usermap_to_file(osguser_groups, file):

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -173,4 +173,3 @@ if __name__ == "__main__":
     except urllib.error.HTTPError as e:
         print(e, file=sys.stderr)
         sys.exit(1)
-

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -4,6 +4,7 @@ import re
 import os
 import sys
 import json
+import time
 import getopt
 import subprocess
 import urllib.error
@@ -16,6 +17,8 @@ OSG_CO_ID = 8
 MINTIMEOUT = 5
 MAXTIMEOUT = 625
 TIMEOUTMULTIPLE = 5
+CACHE_FILENAME = "COmanage_Projects_cache.txt"
+CACHE_LIFETIME_HOURS = 0.5
 
 LDAP_AUTH_COMMAND = [
     "awk", "/ldap_default_authtok/ {print $3}", "/etc/sssd/conf.d/0060_domain_CILOGON.ORG.conf",
@@ -275,14 +278,16 @@ def get_ldap_active_users(filter_group_name):
             stdout=subprocess.PIPE
             ).stdout.decode('utf-8').strip()
 
-    filter_str = ("(isMemberOf=CO:members:active)" if filter_group_name is None else f"(&(isMemberOf={filter_group_name})(isMemberOf=CO:members:active))")
+    filter_str = ("(isMemberOf=CO:members:active)" if filter_group_name is None 
+                  else f"(&(isMemberOf={filter_group_name})(isMemberOf=CO:members:active))")
     
     ldap_active_users_command = LDAP_ACTIVE_USERS_COMMAND
     ldap_active_users_command[LDAP_ACTIVE_USERS_COMMAND.index("{auth}")] = auth_str
     ldap_active_users_command[LDAP_ACTIVE_USERS_COMMAND.index("{filter}")] = filter_str
 
     active_users = subprocess.run(ldap_active_users_command, stdout=subprocess.PIPE).stdout.decode('utf-8').split('\n')
-    users = set(line.replace("voPersonApplicationUID: ", "") if re.compile("dn: voPerson*") else "" for line in active_users)
+    users = set(line.replace("voPersonApplicationUID: ", "") if re.compile("dn: voPerson*") 
+                else "" for line in active_users)
     return users
 
 
@@ -299,14 +304,38 @@ def create_user_to_projects_map(project_to_user_map, active_users, osggids_to_na
     return users_to_projects_map
 
 
-def get_co_api_data():
-    #TODO add cacheing for COManage API data
-
+def get_groups_data_from_api():
     groups = get_osg_co_groups__map()
     project_osggids_to_name = dict()
     for id,name in groups.items():
         if co_group_is_project(id):
             project_osggids_to_name[get_co_group_osggid(id)] = name
+    return project_osggids_to_name
+
+
+def get_co_api_data():
+    try:
+        r = open(CACHE_FILENAME, "r")
+        lines = r.readlines()
+        if float(lines[0]) >= (time.time() - (60 * 60 * CACHE_LIFETIME_HOURS)):
+            entries = lines[1:len(lines)]
+            project_osggids_to_name = dict()
+            for entry in entries:
+                osggid_name_pair = entry.split(":")
+                if len(osggid_name_pair) == 2:
+                    project_osggids_to_name[osggid_name_pair[0]] = osggid_name_pair[1]
+        else:
+            raise OSError
+    except OSError:
+        with open(CACHE_FILENAME, "w") as w:
+            project_osggids_to_name = get_groups_data_from_api()
+            print(time.time(), file=w)
+            for osggid, name in project_osggids_to_name.items():
+                print(f"{osggid}:{name}", file=w)
+    finally:
+        if r:
+            r.close()
+
     return project_osggids_to_name
 
 

--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -6,7 +6,6 @@ import sys
 import json
 import getopt
 import subprocess
-import collections
 import urllib.error
 import urllib.request
 
@@ -28,7 +27,7 @@ LDAP_GROUP_MEMBERS_COMMAND = [
     "ldaps://ldap.cilogon.org",
     "-D",
     "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org",
-    "-w", "{}",
+    "-w", "{auth}",
     "-b",
     "ou=groups,o=OSG,o=CO,dc=cilogon,dc=org",
     "-s",
@@ -42,9 +41,9 @@ LDAP_ACTIVE_USERS_COMMAND = [
     "-H", "ldaps://ldap.cilogon.org",
     "-D", "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org",
     "-x",
-    "-w",  "{}",
+    "-w",  "{auth}",
     "-b", "ou=people,o=OSG,o=CO,dc=cilogon,dc=org",
-    "(isMemberOf=CO:members:active)", "voPersonApplicationUID",
+    "{filter}", "voPersonApplicationUID",
     "|", "grep", "voPersonApplicationUID",
     "|", "sort",
 ]
@@ -242,13 +241,13 @@ def get_ldap_group_members_data():
             ).stdout.decode('utf-8').strip()
     
     ldap_group_members_command = LDAP_GROUP_MEMBERS_COMMAND
-    ldap_group_members_command[LDAP_GROUP_MEMBERS_COMMAND.index("{}")] = auth_str
+    ldap_group_members_command[LDAP_GROUP_MEMBERS_COMMAND.index("{auth}")] = auth_str
 
     data_file = subprocess.run(
         ldap_group_members_command, stdout=subprocess.PIPE).stdout.decode('utf-8').split('\n')
 
     search_results = list(filter( 
-        lambda x: not re.compile("#|dn|cn|objectClass").match(x),
+        lambda x: not re.compile("#|dn:|cn:|objectClass:").match(x),
         (line for line in data_file)))
         
     search_results.reverse()
@@ -270,14 +269,17 @@ def get_ldap_group_members_data():
     return group_data_dict
 
 
-def get_ldap_active_users():
+def get_ldap_active_users(filter_group_name):
     auth_str = subprocess.run(
             LDAP_AUTH_COMMAND,
             stdout=subprocess.PIPE
             ).stdout.decode('utf-8').strip()
+
+    filter_str = ("(isMemberOf=CO:members:active)" if filter_group_name is None else f"(&(isMemberOf={filter_group_name})(isMemberOf=CO:members:active))")
     
     ldap_active_users_command = LDAP_ACTIVE_USERS_COMMAND
-    ldap_active_users_command[LDAP_ACTIVE_USERS_COMMAND.index("{}")] = auth_str
+    ldap_active_users_command[LDAP_ACTIVE_USERS_COMMAND.index("{auth}")] = auth_str
+    ldap_active_users_command[LDAP_ACTIVE_USERS_COMMAND.index("{filter}")] = filter_str
 
     active_users = subprocess.run(ldap_active_users_command, stdout=subprocess.PIPE).stdout.decode('utf-8').split('\n')
     users = set(line.replace("voPersonApplicationUID: ", "") if re.compile("dn: voPerson*") else "" for line in active_users)
@@ -308,28 +310,10 @@ def get_co_api_data():
     return project_osggids_to_name
 
 
-def gid_pids_to_osguser_pid_gids(gid_pids, pid_osguser):
-    pid_gids = collections.defaultdict(set)
-
-    for gid in gid_pids:
-        for pid in gid_pids[gid]:
-            if pid_osguser[pid] is not None:
-                pid_gids[pid].add(gid)
-
-    return pid_gids
-
-
-def filter_by_group(pid_gids, groups, filter_group_name):
-    groups_idx = { v: k for k,v in groups.items() }
-    filter_gid = groups_idx[filter_group_name]  # raises KeyError if missing
-    filter_group_pids = set(get_co_group_members__pids(filter_gid))
-    return { p: g for p,g in pid_gids.items() if p in filter_group_pids }
-
-
 def get_osguser_groups(filter_group_name=None):
     project_osggids_to_name = get_co_api_data()
     ldap_groups_members = get_ldap_group_members_data()
-    ldap_users = get_ldap_active_users()
+    ldap_users = get_ldap_active_users(filter_group_name)
 
     active_project_osggids = set(ldap_groups_members.keys()).intersection(set(project_osggids_to_name.keys()))
     project_to_user_map = {
@@ -345,9 +329,6 @@ def get_osguser_groups(filter_group_name=None):
                                 all_active_project_users,
                                 project_osggids_to_name,
                                 )
-    
-    #if filter_group_name is not None:
-        #pid_gids = filter_by_group(pid_gids, groups, filter_group_name)
 
     return usernames_to_project_map
 

--- a/project_group_setup.py
+++ b/project_group_setup.py
@@ -1,29 +1,17 @@
 #!/usr/bin/env python3
 
 import os
-import re
 import sys
-import json
 import getopt
-import urllib.error
-import urllib.request
-from ldap3 import Server, Connection, ALL, ALL_ATTRIBUTES, SAFE_SYNC
+import comanage_scripts_utils as utils
 
 SCRIPT = os.path.basename(__file__)
 ENDPOINT = "https://registry-test.cilogon.org/registry/"
-LDAP_SERVER = "ldaps://ldap.cilogon.org"
-LDAP_USER = "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org"
+LDAP_SERVER = "ldaps://ldap-test.cilogon.org"
+LDAP_USER = "uid=registry_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org"
 OSG_CO_ID = 8
 UNIX_CLUSTER_ID = 10
 LDAP_TARGET_ID = 9
-MINTIMEOUT = 5
-MAXTIMEOUT = 625
-TIMEOUTMULTIPLE = 5
-
-GET = "GET"
-PUT = "PUT"
-POST = "POST"
-DELETE = "DELETE"
 
 OSPOOL_PROJECT_PREFIX_STR = "Yes-"
 PROJECT_GIDS_START = 200000
@@ -43,8 +31,6 @@ OPTIONS:
   -e ENDPOINT         specify REST endpoint
                         (default = {ENDPOINT})
   -o outfile          specify output file (default: write to stdout)
-  -t minTimeout       set minimum timeout, in seconds, for API call (default to {MINTIMEOUT})
-  -T maxTimeout       set maximum timeout, in seconds, for API call (default to {MAXTIMEOUT})
   -h                  display this help text
 
 PASS for USER is taken from the first of:
@@ -72,165 +58,15 @@ class Options:
     outfile = None
     authstr = None
     ldap_authtok = None
-    min_timeout = MINTIMEOUT
-    max_timeout = MAXTIMEOUT
     project_gid_startval = PROJECT_GIDS_START
 
 
 options = Options()
 
 
-def getpw(user, passfd, passfile):
-    if ":" in user:
-        user, pw = user.split(":", 1)
-    elif passfd is not None:
-        pw = os.fdopen(passfd).readline().rstrip("\n")
-    elif passfile is not None:
-        pw = open(passfile).readline().rstrip("\n")
-    elif "PASS" in os.environ:
-        pw = os.environ["PASS"]
-    else:
-        usage("PASS required")
-    return user, pw
-
-
-def mkauthstr(user, passwd):
-    from base64 import encodebytes
-
-    raw_authstr = "%s:%s" % (user, passwd)
-    return encodebytes(raw_authstr.encode()).decode().replace("\n", "")
-
-
-def mkrequest(method, target, data, **kw):
-    url = os.path.join(options.endpoint, target)
-    if kw:
-        url += "?" + "&".join("{}={}".format(k, v) for k, v in kw.items())
-    req = urllib.request.Request(url, json.dumps(data).encode("utf-8"))
-    req.add_header("Authorization", "Basic %s" % options.authstr)
-    req.add_header("Content-Type", "application/json")
-    req.get_method = lambda: method
-    return req
-
-
-def call_api(target, **kw):
-    return call_api2(GET, target, **kw)
-
-
-def call_api2(method, target, **kw):
-    return call_api3(method, target, data=None, **kw)
-
-
-def call_api3(method, target, data, **kw):
-    req = mkrequest(method, target, data, **kw)
-    trying = True
-    currentTimeout = options.min_timeout
-    while trying:
-        try:
-            resp = urllib.request.urlopen(req, timeout=currentTimeout)
-            payload = resp.read()
-            trying = False
-        except urllib.error.URLError as exception:
-            if currentTimeout < options.max_timeout:
-                currentTimeout *= TIMEOUTMULTIPLE
-            else:
-                sys.exit(
-                    f"Exception raised after maximum retrys and timeout {options.max_timeout} seconds reached. "
-                    + f"Exception reason: {exception.reason}.\n Request: {req.full_url}"
-                )
-
-    return json.loads(payload) if payload else None
-
-
-def get_osg_co_groups():
-    return call_api("co_groups.json", coid=options.osg_co_id)
-
-
-# primary api calls
-
-
-def get_co_group_identifiers(gid):
-    return call_api("identifiers.json", cogroupid=gid)
-
-
-def get_co_group_members(gid):
-    return call_api("co_group_members.json", cogroupid=gid)
-
-
-def get_co_person_identifiers(pid):
-    return call_api("identifiers.json", copersonid=pid)
-
-
-def get_unix_cluster_groups(ucid):
-    return call_api("unix_cluster/unix_cluster_groups.json", unix_cluster_id=ucid)
-
-
-def get_unix_cluster_groups_ids(ucid):
-    unix_cluster_groups = get_unix_cluster_groups(ucid)
-    return set(group["CoGroupId"] for group in unix_cluster_groups["UnixClusterGroups"])
-
-
-def get_datalist(data, listname):
-    return data[listname] if data else []
-
-
-def get_ldap_groups():
-    ldap_group_osggids = set()
-    server = Server(LDAP_SERVER, get_info=ALL)
-    connection = Connection(server, LDAP_USER, options.ldap_authtok, client_strategy=SAFE_SYNC, auto_bind=True)
-    _, _, response, _ = connection.search("ou=groups,o=OSG,o=CO,dc=cilogon,dc=org", "(cn=*)", attributes=ALL_ATTRIBUTES)
-    for group in response:
-        ldap_group_osggids.add(group["attributes"]["gidNumber"])
-    return ldap_group_osggids
-
-
-def identifier_from_list(id_list, id_type):
-    id_type_list = [id["Type"] for id in id_list]
-    try:
-        id_index = id_type_list.index(id_type)
-        return id_list[id_index]["Identifier"]
-    except ValueError:
-        return None
-
-
-def identifier_matches(id_list, id_type, regex_string):
-    pattern = re.compile(regex_string)
-    value = identifier_from_list(id_list, id_type)
-    return (value is not None) & (pattern.match(value) is not None)
-
-
-def add_identifier_to_group(gid, type, identifier_value):
-    new_identifier_info = {
-        "Version": "1.0",
-        "Type": type,
-        "Identifier": identifier_value,
-        "Login": False,
-        "Person": {"Type": "Group", "Id": str(gid)},
-        "Status": "Active",
-    }
-    data = {
-        "RequestType": "Identifiers",
-        "Version": "1.0",
-        "Identifiers": [new_identifier_info],
-    }
-    call_api3(POST, "identifiers.json", data)
-
-
-def add_unix_cluster_group(gid):
-    request = {
-        "RequestType": "UnixClusterGroups",
-        "Version": "1.0",
-        "UnixClusterGroups": [{"Version": "1.0", "UnixClusterId": options.ucid, "CoGroupId": gid}],
-    }
-    call_api3(POST, "unix_cluster/unix_cluster_groups.json", request)
-
-
-def ldap_provision_group(gid):
-    call_api2(POST, f"co_provisioning_targets/provision/{options.provision_target}/cogroupid:{gid}.json")
-
-
 def parse_options(args):
     try:
-        ops, args = getopt.getopt(args, "u:c:g:l:p:d:f:e:o:t:T:h")
+        ops, args = getopt.getopt(args, "u:c:g:l:p:d:f:e:o:h")
     except getopt.GetoptError:
         usage()
 
@@ -261,25 +97,24 @@ def parse_options(args):
             options.endpoint = arg
         if op == "-o":
             options.outfile = arg
-        if op == "-t":
-            options.min_timeout = float(arg)
-        if op == "-T":
-            options.max_timeout = float(arg)
 
-    user, passwd = getpw(options.user, passfd, passfile)
-    options.authstr = mkauthstr(user, passwd)
+    try:
+        user, passwd = utils.getpw(options.user, passfd, passfile)
+        options.authstr = utils.mkauthstr(user, passwd)
+    except PermissionError:
+        usage("PASS required")
 
 
 def append_if_project(project_groups, group):
     # If this group has a ospoolproject id, and it starts with "Yes-", it's a project
-    if identifier_matches(group["ID_List"], "ospoolproject", (OSPOOL_PROJECT_PREFIX_STR + "*")):
+    if utils.identifier_matches(group["ID_List"], "ospoolproject", (OSPOOL_PROJECT_PREFIX_STR + "*")):
         # Add a dict of the relavent data for this project to the project_groups list
         project_groups.append(group)
 
 
 def update_highest_osggid(highest_osggid, group):
     # Get the value of the osggid identifier, if this group has one
-    osggid = identifier_from_list(group["ID_List"], "osggid")
+    osggid = utils.identifier_from_list(group["ID_List"], "osggid")
     # If this group has a osggid, keep a hold of the highest one we've seen so far
     if osggid is not None:
         return max(highest_osggid, int(osggid))
@@ -290,12 +125,12 @@ def update_highest_osggid(highest_osggid, group):
 def get_comanage_data():
     comanage_data = {"Projects": [], "highest_osggid": 0}
 
-    co_groups = get_osg_co_groups()["CoGroups"]
+    co_groups = utils.get_osg_co_groups(options.osg_co_id, options.endpoint, options.authstr)["CoGroups"]
     for group_data in co_groups:
         try:
-            identifier_list = get_co_group_identifiers(group_data["Id"])["Identifiers"]
+            identifier_list = utils.get_co_group_identifiers(group_data["Id"], options.endpoint, options.authstr)
             # Store this groups data in a dictionary to avoid repeated API calls
-            group = {"Gid": group_data["Id"], "Name": group_data["Name"], "ID_List": identifier_list}
+            group = {"Gid": group_data["Id"], "Name": group_data["Name"], "ID_List": identifier_list["Identifiers"]}
 
             append_if_project(comanage_data["Projects"], group)
 
@@ -309,7 +144,7 @@ def get_projects_needing_identifiers(project_groups):
     projects_needing_identifiers = []
     for project in project_groups:
         # If this project doesn't have an osggid already assigned to it...
-        if identifier_from_list(project["ID_List"], "osggid") is None:
+        if utils.identifier_from_list(project["ID_List"], "osggid") is None:
             # Prep the project to have the proper identifiers added to it
             projects_needing_identifiers.append(project)
     return projects_needing_identifiers
@@ -317,7 +152,7 @@ def get_projects_needing_identifiers(project_groups):
 
 def get_projects_needing_cluster_groups(project_groups):
     # CO Groups associated with a UNIX Cluster Group
-    clustered_group_ids = get_unix_cluster_groups_ids(options.ucid)
+    clustered_group_ids = utils.get_unix_cluster_groups_ids(options.ucid, options.endpoint, options.authstr)
     try:
         # All project Gids
         project_gids = set(project["Gid"] for project in project_groups)
@@ -336,17 +171,19 @@ def get_projects_needing_cluster_groups(project_groups):
 
 def get_projects_needing_provisioning(project_groups):
     # project groups provisioned in LDAP
-    ldap_group_osggids = get_ldap_groups()
+    ldap_group_osggids = utils.get_ldap_groups(LDAP_SERVER, LDAP_USER, options.ldap_authtok)
     try:
         # All project osggids
-        project_osggids = set(identifier_from_list(project["ID_List"], "osggid") for project in project_groups)
+        project_osggids = set(
+            int(utils.identifier_from_list(project["ID_List"], "osggid")) for project in project_groups
+        )
         # project osggids not provisioned in ldap
         project_osggids_to_provision = project_osggids.difference(ldap_group_osggids)
         # All projects that aren't provisioned in ldap
         projects_to_provision = (
             project
             for project in project_groups
-            if identifier_from_list(project["ID_List"], "osggid") in project_osggids_to_provision
+            if int(utils.identifier_from_list(project["ID_List"], "osggid")) in project_osggids_to_provision
         )
         return projects_to_provision
     except TypeError:
@@ -364,8 +201,8 @@ def get_projects_to_setup(project_groups):
 
 def add_missing_group_identifier(project, id_type, value):
     # If the group doesn't already have an id of this type...
-    if identifier_from_list(project["ID_List"], id_type) is None:
-        add_identifier_to_group(project["Gid"], id_type, value)
+    if utils.identifier_from_list(project["ID_List"], id_type) is None:
+        utils.add_identifier_to_group(project["Gid"], id_type, value, options.endpoint, options.authstr)
         print(f'project {project["Gid"]}: aded id {value} of type {id_type}')
 
 
@@ -393,13 +230,13 @@ def assign_identifiers(project_list, highest_osggid):
 
 def create_unix_cluster_groups(project_list):
     for project in project_list:
-        add_unix_cluster_group(project["Gid"])
+        utils.add_unix_cluster_group(project["Gid"], options.ucid, options.endpoint, options.authstr)
         print(f'project group {project["Gid"]}: added UNIX Cluster Group')
 
 
 def provision_groups(project_list):
     for project in project_list:
-        ldap_provision_group(project["Gid"])
+        utils.provision_group(project["Gid"], options.provision_target, options.endpoint, options.authstr)
         print(f'project group {project["Gid"]}: Provisioned Group')
 
 

--- a/project_group_setup.py
+++ b/project_group_setup.py
@@ -4,13 +4,15 @@ import os
 import re
 import sys
 import json
-#import ldap3
 import getopt
 import urllib.error
 import urllib.request
+from ldap3 import Server, Connection, ALL, ALL_ATTRIBUTES, SAFE_SYNC
 
 SCRIPT = os.path.basename(__file__)
 ENDPOINT = "https://registry-test.cilogon.org/registry/"
+LDAP_SERVER = "ldaps://ldap.cilogon.org"
+LDAP_USER = "uid=readonly_user,ou=system,o=OSG,o=CO,dc=cilogon,dc=org"
 OSG_CO_ID = 8
 UNIX_CLUSTER_ID = 10
 LDAP_TARGET_ID = 9
@@ -35,6 +37,7 @@ OPTIONS:
   -c OSG_CO_ID        specify OSG CO ID (default = {OSG_CO_ID})
   -g CLUSTER_ID       specify UNIX Cluster ID (default = {UNIX_CLUSTER_ID})
   -l LDAP_TARGET      specify LDAP Provsion ID (defult = {LDAP_TARGET_ID})
+  -p LDAP authtok     specify LDAP server authtok
   -d passfd           specify open fd to read PASS
   -f passfile         specify path to file to open and read PASS
   -e ENDPOINT         specify REST endpoint
@@ -68,6 +71,7 @@ class Options:
     provision_target = LDAP_TARGET_ID
     outfile = None
     authstr = None
+    ldap_authtok = None
     min_timeout = MINTIMEOUT
     max_timeout = MAXTIMEOUT
     project_gid_startval = PROJECT_GIDS_START
@@ -169,6 +173,16 @@ def get_datalist(data, listname):
     return data[listname] if data else []
 
 
+def get_ldap_groups():
+    ldap_group_osggids = set()
+    server = Server(LDAP_SERVER, get_info=ALL)
+    connection = Connection(server, LDAP_USER, options.ldap_authtok, client_strategy=SAFE_SYNC, auto_bind=True)
+    _, _, response, _ = connection.search("ou=groups,o=OSG,o=CO,dc=cilogon,dc=org", "(cn=*)", attributes=ALL_ATTRIBUTES)
+    for group in response:
+        ldap_group_osggids.add(group["attributes"]["gidNumber"])
+    return ldap_group_osggids
+
+
 def identifier_from_list(id_list, id_type):
     id_type_list = [id["Type"] for id in id_list]
     try:
@@ -216,7 +230,7 @@ def ldap_provision_group(gid):
 
 def parse_options(args):
     try:
-        ops, args = getopt.getopt(args, "u:c:d:f:e:o:t:T:h")
+        ops, args = getopt.getopt(args, "u:c:g:l:p:d:f:e:o:t:T:h")
     except getopt.GetoptError:
         usage()
 
@@ -237,6 +251,8 @@ def parse_options(args):
             options.ucid = int(arg)
         if op == "-l":
             options.provision_target = int(arg)
+        if op == "-p":
+            options.ldap_authtok = arg
         if op == "-d":
             passfd = int(arg)
         if op == "-f":
@@ -267,6 +283,8 @@ def update_highest_osggid(highest_osggid, group):
     # If this group has a osggid, keep a hold of the highest one we've seen so far
     if osggid is not None:
         return max(highest_osggid, int(osggid))
+    else:
+        return highest_osggid
 
 
 def get_comanage_data():
@@ -287,28 +305,60 @@ def get_comanage_data():
     return comanage_data
 
 
-def get_projects_to_setup(project_groups):
-    projects_to_setup = {
-        "Need Identifiers": [],
-        "Need Cluster Groups": [],
-        "Need Provisioning": [],
-    }
-
-    # CO Groups associated with a UNIX Cluster Group
-    clustered_group_ids = get_unix_cluster_groups_ids(options.ucid)
-
+def get_projects_needing_identifiers(project_groups):
+    projects_needing_identifiers = []
     for project in project_groups:
         # If this project doesn't have an osggid already assigned to it...
         if identifier_from_list(project["ID_List"], "osggid") is None:
             # Prep the project to have the proper identifiers added to it
-            projects_to_setup["Need Identifiers"].append(project)
+            projects_needing_identifiers.append(project)
+    return projects_needing_identifiers
 
-        # If this project doesn't have a UNIX Cluster Group associated with it...
-        if not project["Gid"] in clustered_group_ids:
-            # Prep it to have one made for it and to be provisioned in LDAP
-            projects_to_setup["Need Cluster Groups"].append(project)
-            projects_to_setup["Need Provisioning"].append(project)
 
+def get_projects_needing_cluster_groups(project_groups):
+    # CO Groups associated with a UNIX Cluster Group
+    clustered_group_ids = get_unix_cluster_groups_ids(options.ucid)
+    try:
+        # All project Gids
+        project_gids = set(project["Gid"] for project in project_groups)
+        # Project Gids for projects without UNIX cluster groups
+        project_gids_lacking_cluster_groups = project_gids.difference(clustered_group_ids)
+        # All projects needing UNIX cluster groups
+        projects_needing_unix_groups = (
+            project
+            for project in project_groups
+            if project["Gid"] in project_gids_lacking_cluster_groups
+        )
+        return projects_needing_unix_groups
+    except TypeError:
+        return set()
+    
+
+def get_projects_needing_provisioning(project_groups):
+    # project groups provisioned in LDAP
+    ldap_group_osggids = get_ldap_groups()
+    try:
+        # All project osggids
+        project_osggids = set(identifier_from_list(project["ID_List"], "osggid") for project in project_groups)
+        # project osggids not provisioned in ldap
+        project_osggids_to_provision = project_osggids.difference(ldap_group_osggids)
+        # All projects that aren't provisioned in ldap
+        projects_to_provision = (
+            project
+            for project in project_groups
+            if identifier_from_list(project["ID_List"], "osggid") in project_osggids_to_provision
+        )
+        return projects_to_provision
+    except TypeError:
+        return set()
+
+
+def get_projects_to_setup(project_groups):
+    projects_to_setup = {
+        "Need Identifiers": get_projects_needing_identifiers(project_groups),
+        "Need Cluster Groups": get_projects_needing_cluster_groups(project_groups),
+        "Need Provisioning": get_projects_needing_provisioning(project_groups),
+    }
     return projects_to_setup
 
 

--- a/project_group_setup.py
+++ b/project_group_setup.py
@@ -194,14 +194,14 @@ def add_missing_group_identifier(project, id_type, value):
     # If the group doesn't already have an id of this type...
     if utils.identifier_from_list(project["ID_List"], id_type) is None:
         utils.add_identifier_to_group(project["Gid"], id_type, value, options.endpoint, options.authstr)
-        print(f'project {project["Gid"]}: aded id {value} of type {id_type}')
+        print(f'project {project["Gid"]}: added id {value} of type {id_type}')
 
 
 def assign_identifiers_to_project(project, id_dict):
     for k, v in id_dict.items():
         # Add an identifier of type k and value v to this group, if it doesn't have them already
         add_missing_group_identifier(project, k, v)
-    # Update the project object to incldue the new identifiers
+    # Update the project object to include the new identifiers
     new_identifiers = utils.get_co_group_identifiers(project["Gid"], options.endpoint, options.authstr)["Identifiers"]
     project["ID_List"] = new_identifiers
 


### PR DESCRIPTION
Uses LDAP for determining group membership.

Uses LDAP to determine active users, and only adds a user to the map if they are active (from SOFTWARE-5413)

Still uses the COmanage API to find out which CO groups are projects, but now caches them so if the map needs to be recreated in a short amount of time, it doesn't need to make so many API calls (cache currently stales after 0.5 hours, but changing it should only take changing a global)