### PR TITLE
Temporary fix for project_usermap ex-members (INF-1060)

### DIFF
--- a/osg-comanage-project-usermap.py
+++ b/osg-comanage-project-usermap.py
@@ -153,7 +153,8 @@ def get_co_group_members__pids(gid):
     #print(f"get_co_group_members__pids({gid})")
     resp_data = get_co_group_members(gid)
     data = get_datalist(resp_data, "CoGroupMembers")
-    return [ m["Person"]["Id"] for m in data ]
+    # For INF-1060: Temporary Fix until "The Great Project Provisioning" is finished
+    return [ m["Person"]["Id"] for m in data if m["Member"] == True]
 
 
 def get_co_person_osguser(pid):


### PR DESCRIPTION
Added a quick check to ensure that group member pids are only taken from CO People who currently have Member = True in their GroupMember data. This allows us to remove CO People from the project_usermap simply by removing them as members via the registry website.